### PR TITLE
fix: remove deprecated time unit

### DIFF
--- a/lib/aws_ex_ray/util.ex
+++ b/lib/aws_ex_ray/util.ex
@@ -13,7 +13,7 @@
     @spec generate_trace_id() :: String.t
     def generate_trace_id() do
       t = DateTime.utc_now
-          |> DateTime.to_unix(:seconds)
+          |> DateTime.to_unix(:second)
           |> Integer.to_string(16)
           |> String.downcase()
       "1-#{t}-#{SecureRandom.hex(12)}"


### PR DESCRIPTION
When using aws_ex_ray plug, I'm getting this warning 

> warning: deprecated time unit: :microseconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer
  (elixir) lib/calendar/datetime.ex:537: DateTime.to_unix/2
  (aws_ex_ray) lib/aws_ex_ray/util.ex:9: AwsExRay.Util.now/0
  (aws_ex_ray) lib/aws_ex_ray/segment.ex:46: AwsExRay.Segment.new/2
  (aws_ex_ray) lib/aws_ex_ray.ex:256: AwsExRay.start_tracing/2