### PR TITLE
Sysmte.cwd replace to File.cwd

### DIFF
--- a/lib/aws_ex_ray/record/error/cause.ex
+++ b/lib/aws_ex_ray/record/error/cause.ex
@@ -47,9 +47,9 @@ defmodule AwsExRay.Record.Error.Cause do
   end
 
   defp cwd() do
-    case System.cwd() do
-      nil -> ""
-      dir -> dir
+    case File.cwd() do
+      {:ok, dir} -> dir
+      _ -> ""
     end
   end
 


### PR DESCRIPTION
when aws_ex_ray with Elixir 1.9.0, I got this warning message.
```
==> aws_ex_ray                                                                                                                                                             [330/1859]
Compiling 26 files (.ex)
warning: System.cwd/0 is deprecated. Use File.cwd/0 instead
  lib/aws_ex_ray/record/error/cause.ex:50
```